### PR TITLE
Setup Dependabot and update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: actions/restore_artifacts
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: github-actions
+    directory: actions/save_artifacts
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: github-actions
+    directory: actions/setup_environment
+    schedule:
+      interval: "weekly"

--- a/actions/restore_artifacts/action.yml
+++ b/actions/restore_artifacts/action.yml
@@ -6,7 +6,7 @@ runs:
   using: composite
   steps:
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: artifact
         path: .artifacts

--- a/actions/save_artifacts/action.yml
+++ b/actions/save_artifacts/action.yml
@@ -12,6 +12,6 @@ runs:
         tar cvf artifact.tar ${{ inputs.directory }}
         mv artifact.tar artifact-$(sha1sum artifact.tar|awk '{ print $1 }').tar
       shell: bash
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         path: artifact-*.tar

--- a/actions/setup_environment/action.yml
+++ b/actions/setup_environment/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       if: inputs.enable_go == 'true'
       with:
         path: |
@@ -24,7 +24,7 @@ runs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - uses: actions/cache@v3
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       if: inputs.enable_npm == 'true'
       with:
         path: |
@@ -36,8 +36,8 @@ runs:
       shell: bash
       if: inputs.enable_go == 'true'
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
       if: inputs.enable_docker_multibuild == 'true'
     - name: Set up buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
       if: inputs.enable_docker_multibuild == 'true'


### PR DESCRIPTION
* Bump actions/download-artifact from 3 to 4.1.8 in /actions/restore_artifacts
* Bump actions/upload-artifact from 3 to 4.3.4 in /actions/save_artifacts
* Bump actions/cache from 3 to 4.0.2 in /actions/setup_environment
* Bump docker/setup-buildx-action in /actions/setup_environment
* Bump docker/setup-qemu-action from 1 to 3.2.0 in /actions/setup_environment