### PR TITLE
Fix top-level action tag.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,4 +7,4 @@ runs:
       with:
         repository: 'prometheus/promci'
         path: '.github/promci'
-        ref: v0.3.0
+        ref: v0.4.2


### PR DESCRIPTION
This tag needs to be set prior to release tagging.