### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,4 +7,4 @@ runs:
       with:
         repository: 'prometheus/promci'
         path: '.github/promci'
-        ref: v0.4.4
+        ref: v0.4.6


### PR DESCRIPTION
Bumping main version to 0.4.6 before releasing 0.4.6 tag.

Otherwise everyone who references 0.4.5 or main commit still gets 0.4.4