### PR TITLE
Fix latest container tag publishing

### DIFF
--- a/actions/publish_release_images/action.yml
+++ b/actions/publish_release_images/action.yml
@@ -38,16 +38,24 @@ runs:
       shell: bash
     - run: |
         current_tag=${GITHUB_REF#refs/*/}
+        latest_tag=$(git tag --sort=v:refname  | tail -n 1)
+        reg_repo=${{ inputs.registry }}/${{ inputs.organization }}
         touch /tmp/tmp-profile
         . /tmp/tmp-profile
-        make docker DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
+        make docker DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO="${reg_repo}"
         docker images
         echo ${{ inputs.password }} | docker login -u ${{ inputs.login }} --password-stdin ${{ inputs.registry }}
-        make docker-publish DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-        make docker-manifest DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-        if [[ "$current_tag" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
-          make docker-tag-latest DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-          make docker-publish DOCKER_IMAGE_TAG="latest" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-          make docker-manifest DOCKER_IMAGE_TAG="latest" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
+        make docker-publish DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO="${reg_repo}"
+        make docker-manifest DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO="${reg_repo}"
+        if [[ "${current_tag}" == "${latest_tag}" ]]; then
+          if [[ "${current_tag}" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
+            make docker-tag-latest DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO="${reg_repo}"
+            make docker-publish DOCKER_IMAGE_TAG="latest" DOCKER_REPO="${reg_repo}"
+            make docker-manifest DOCKER_IMAGE_TAG="latest" DOCKER_REPO="${reg_repo}"
+          else
+            echo "INFO: ${current_tag} is probably a pre-release, skipping latest tag"
+          fi
+        else
+          echo "INFO: ${current_tag} is not ${latest_tag}, skipping latest tag"
         fi
       shell: bash


### PR DESCRIPTION
Check the current tag against the list of all tags to make sure that it is the actual latest tag before attempting to publish the container `latest` tag. This avoids updating the `latest` tag when pushing bug fixes to older release branchs.

Fixes: https://github.com/prometheus/prometheus/issues/16238