### PR TITLE
Use docker Github actions to tag containers

### DIFF
--- a/actions/publish_images/action.yml
+++ b/actions/publish_images/action.yml
@@ -20,34 +20,48 @@ inputs:
     description: Path to Dockerbuild context
     type: string
     default: ""
+  platforms:
+    description: Docker platforms to build
+    type: string
+    default: "linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x"
   container_image_name:
     description: Name of the container image
     type: string
-    default: ""
+    default: ${{ github.event.repository.name }}
+  github_token:
+    type: string
+    description: Github Token
   docker_image_tag:
     description: A custom image tag to be added
     type: string
 runs:
   using: composite
   steps:
-    - if: inputs.dockerfile_path != ''
-      run: echo "export DOCKERFILE_PATH=${{ inputs.dockerfile_path }}" >> /tmp/tmp-profile
-      shell: bash
-    - if: inputs.container_image_name != ''
-      run: echo "export DOCKER_IMAGE_NAME=${{ inputs.container_image_name }}" >> /tmp/tmp-profile
-      shell: bash
-    - if: inputs.dockerbuild_context != ''
-      run: echo "export DOCKERBUILD_CONTEXT=${{ inputs.dockerbuild_context }}" >> /tmp/tmp-profile
-      shell: bash
-    - if: inputs.docker_image_tag != ''
-      run: echo "export DOCKER_IMAGE_TAG=${{ inputs.docker_image_tag }}" >> /tmp/tmp-profile
-      shell: bash
-    - run: |
-        touch /tmp/tmp-profile
-        . /tmp/tmp-profile
-        make docker DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-        docker images
-        echo ${{ inputs.password }} | docker login -u ${{ inputs.login }} --password-stdin ${{ inputs.registry }}
-        make docker-publish DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-        make docker-manifest DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-      shell: bash
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+      with:
+        github-token: ${{ inputs.github_token }}
+        images: |
+          ${{ inputs.registry }}/${{ inputs.organization }}/${{ inputs.container_image_name }}
+        flavor: |
+          latest=false
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.login }}
+        password: ${{ inputs.password }}
+    - name: Build and push
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      with:
+        context: ${{ inputs.dockerbuild_context || '.' }}
+        file: ${{ inputs.dockerfile_path }}
+        platforms: ${{ inputs.platforms }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/actions/publish_main/action.yml
+++ b/actions/publish_main/action.yml
@@ -20,6 +20,9 @@ inputs:
   quay_io_password:
     type: string
     description: Quay.io password
+  github_token:
+    type: string
+    description: Github Token
 runs:
   using: composite
   steps:
@@ -34,6 +37,7 @@ runs:
         organization: ${{ inputs.docker_hub_organization }}
         login: ${{ inputs.docker_hub_login }}
         password: ${{ inputs.docker_hub_password }}
+        github_token: ${{ inputs.github_token }}
     - uses: ./.github/promci/actions/publish_images
       if: inputs.quay_io_organization != '' && inputs.quay_io_login != ''
       with:
@@ -41,3 +45,4 @@ runs:
         organization: ${{ inputs.quay_io_organization }}
         login: ${{ inputs.quay_io_login }}
         password: ${{ inputs.quay_io_password }}
+        github_token: ${{ inputs.github_token }}

--- a/actions/publish_release/action.yml
+++ b/actions/publish_release/action.yml
@@ -49,6 +49,7 @@ runs:
         organization: ${{ inputs.docker_hub_organization }}
         login: ${{ inputs.docker_hub_login }}
         password: ${{ inputs.docker_hub_password }}
+        github_token: ${{ inputs.github_token }}
     - uses: ./.github/promci/actions/publish_release_images
       if: inputs.quay_io_organization != '' && inputs.quay_io_login != ''
       with:
@@ -56,6 +57,7 @@ runs:
         organization: ${{ inputs.quay_io_organization }}
         login: ${{ inputs.quay_io_login }}
         password: ${{ inputs.quay_io_password }}
+        github_token: ${{ inputs.github_token }}
     - uses: ./.github/promci/actions/publish_release_images
       if: inputs.ghcr_io_organization != '' && inputs.ghcr_io_login != ''
       with:
@@ -63,3 +65,4 @@ runs:
         organization: ${{ inputs.ghcr_io_organization }}
         login: ${{ inputs.ghcr_io_login }}
         password: ${{ inputs.ghcr_io_password }}
+        github_token: ${{ inputs.github_token }}

--- a/actions/publish_release_images/action.yml
+++ b/actions/publish_release_images/action.yml
@@ -20,34 +20,55 @@ inputs:
     description: Path to Dockerbuild context
     type: string
     default: ""
+  platforms:
+    description: Docker platforms to build
+    type: string
+    default: "linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x"
   container_image_name:
     description: Name of the container image
     type: string
-    default: ""
+    default: ${{ github.event.repository.name }}
+  github_token:
+    type: string
+    description: Github Token
 runs:
   using: composite
   steps:
-    - if: inputs.dockerfile_path != ''
-      run: echo "export DOCKERFILE_PATH=${{ inputs.dockerfile_path }}" >> /tmp/tmp-profile
-      shell: bash
-    - if: inputs.container_image_name != ''
-      run: echo "export DOCKER_IMAGE_NAME=${{ inputs.container_image_name }}" >> /tmp/tmp-profile
-      shell: bash
-    - if: inputs.dockerbuild_context != ''
-      run: echo "export DOCKERBUILD_CONTEXT=${{ inputs.dockerbuild_context }}" >> /tmp/tmp-profile
-      shell: bash
-    - run: |
-        current_tag=${GITHUB_REF#refs/*/}
-        touch /tmp/tmp-profile
-        . /tmp/tmp-profile
-        make docker DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-        docker images
-        echo ${{ inputs.password }} | docker login -u ${{ inputs.login }} --password-stdin ${{ inputs.registry }}
-        make docker-publish DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-        make docker-manifest DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-        if [[ "$current_tag" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
-          make docker-tag-latest DOCKER_IMAGE_TAG="$current_tag" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-          make docker-publish DOCKER_IMAGE_TAG="latest" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
-          make docker-manifest DOCKER_IMAGE_TAG="latest" DOCKER_REPO=${{ inputs.registry }}/${{ inputs.organization }}
+    - name: Determine latest
+      id: update_latest
+      run: |
+        if [ ${{ startsWith(github.ref, 'refs/tags/v3.') }} ]
+        then
+            echo "::set-output name=latest::auto"
+        else
+            echo "::set-output name=latest::false"
         fi
-      shell: bash
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+      with:
+        github-token: ${{ inputs.github_token }}
+        images: |
+          ${{ inputs.registry }}/${{ inputs.organization }}/${{ inputs.container_image_name }}
+        flavor: |
+          latest=${{ steps.update_latest.outputs.latest }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.login }}
+        password: ${{ inputs.password }}
+    - name: Build and push
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      with:
+        context: ${{ inputs.dockerbuild_context || '.' }}
+        file: ${{ inputs.dockerfile_path }}
+        platforms: ${{ inputs.platforms }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/16238
Rewrite of https://github.com/prometheus/promci/pull/41

This PR changes promci to use `docker/metadata-action` to generate tags for the generated docker containers. We also get nice labels pulled from the Github project metadata for free. The PR also replaces calls to `make docker`, `make docker-publish` and `make docker-manifest` with `docker/build-push-action` which will build the specified Dockerfile for all specified platforms and push them with the specified tags.

Please note that I'm certainly not a Github actions expert and this is just my first attempt at implementing what I understand to be best practices for building and pushing docker images using GH actions. Please review carefully!

Of particular note: using `docker/build-push-action` may not be strictly necessary. It is likely possible to modify the Makefile in the prometheus project to accept the set of tags produced by `docker/metadata-action`. It seemed that using build-push-action was a better solution though as it requires less synchronization between the two repos and that restructuring the Makefile to consume a set of tags instead of just one was going to be more trouble than it's worth, as the Makefile target is only one or two `docker` commands. Keeping the changes only in the `promci` repo seemed easier and simpler.

If this change is accepted, the `prometheus` repo will need a follow-up PR to update the SHA of the `promci` action and will also need to specify the `github_token` input when calling `publish_main` in addition to `publish_release`.

I had quite a bit of difficulty testing this change locally. I was able to locally verify the tags and labels generated by `metadata-action` when called with a `push` action to `refs/tags/v3.5.0` using `act`:

```
[CI/Publish release artefacts]   ⚙  ::set-output:: tags=docker.io/prom/prometheus:3.5.0
docker.io/prom/prometheus:3.5
docker.io/prom/prometheus:3
docker.io/prom/prometheus:latest
[CI/Publish release artefacts]   ⚙  ::set-output:: labels=org.opencontainers.image.created=2025-09-10T04:45:19.579Z
org.opencontainers.image.description=The Prometheus monitoring system and time series database.
org.opencontainers.image.licenses=Apache-2.0
org.opencontainers.image.revision=8be3a9560fbdd18a94dedec4b747c35178177202
org.opencontainers.image.source=https://github.com/prometheus/prometheus
org.opencontainers.image.title=prometheus
org.opencontainers.image.url=https://github.com/prometheus/prometheus
org.opencontainers.image.version=3.5.0
```

I was not able to successfully test actually building and pushing the docker image though, as I wasn't able to get the full CI build and test system running without error locally. I would love some advice on how to properly test these changes using the full CI pipeline, if possible.