### PR TITLE
restore: delete artifact archive immediately

### DIFF
--- a/actions/restore_artifacts/action.yml
+++ b/actions/restore_artifacts/action.yml
@@ -15,6 +15,6 @@ runs:
         for tar in .artifacts/*.tar
         do
           tar xvf $tar
+          rm $tar
         done
-        rm -v .artifacts/*.tar
       shell: bash


### PR DESCRIPTION
If we untar all and then delete all archive the action runner can run out of disk storage.