### PR TITLE
Add new build and publish actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,19 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: github-actions
-    directory: actions/restore_artifacts
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: github-actions
-    directory: actions/save_artifacts
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: github-actions
-    directory: actions/setup_environment
-    schedule:
+    directories:
+      - /.github/workflows
+      - /
+      - /build
+      - /publish_main
+      - /publish_release
+      - /actions/build
+      - /actions/check_proto
+      - /actions/publish_images
+      - /actions/publish_main
+      - /actions/publish_release
+      - /actions/publish_release_images
+      - /actions/restore_artifacts
+      - /actions/save_artifacts
+      - /actions/setup_environment
       interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+---
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main, 'release-*']
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate Workflows and Custom Actions
+        uses: superq/action-validator@97a4e9c86388ddcc54614fb3e849a2fd4f7e124d # https://github.com/mpalmer/action-validator/pull/117
+        with:
+          patterns: |-
+            .github/workflows/*.yml
+            build/action.yml
+            publish_main/action.yml
+            publish_release/action.yml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
 # Prometheus Github Actions
 
 Set of GitHub actions shared by GitHub projects in the Prometheus Ecosystem.
+
+### Usage
+
+```yaml
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prometheus/promci/build@<sha> # v0.6.0
+
+  publish_main:
+    needs: [build]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: prometheus/promci/publish_main@<sha> # v0.6.0
+        with:
+          docker_hub_login: ${{ secrets.docker_hub_login }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_login: ${{ secrets.quay_io_login }}
+          quay_io_password: ${{ secrets.quay_io_password }}
+
+  publish_release:
+    needs: [build]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: prometheus/promci/publish_release@<sha> # v0.6.0
+        with:
+          docker_hub_login: ${{ secrets.docker_hub_login }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_login: ${{ secrets.quay_io_login }}
+          quay_io_password: ${{ secrets.quay_io_password }}
+          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}
+```

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,10 @@
 name: PromCI
-description: An action used by the Prometheus project to share github actions.
+description: An action used by the Prometheus project to share github actions. (Deprecated)
 runs:
   using: composite
   steps:
+    - name: "WARNING: Deprecated action"
+      run: echo "This action has been deprecated in favor of prometheus/promci/<action>@<sha> actions"
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: 'prometheus/promci'

--- a/build/action.yml
+++ b/build/action.yml
@@ -1,0 +1,25 @@
+---
+name: Build
+description: Build Prometheus binaries.
+inputs:
+  thread:
+    description: Current thread
+    required: true
+    default: "3"
+  parallelism:
+    description: Number of builds to do in parallel
+    default: "3"
+  promu_config:
+    description: Config file for promu
+    default: .promu.yml
+  promu_opts:
+    description: Options to pass to promu
+runs:
+  using: composite
+  steps:
+    - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
+    - run: ~/go/bin/promu -c ${{ inputs.promu_config }} crossbuild -v --parallelism ${{ inputs.parallelism }} --parallelism-thread ${{ inputs.thread }} ${{ inputs.promu_opts }}
+      shell: bash
+    - uses: prometheus/promci-artifacts/save@f9a587dbc0b2c78a0c54f8ad1cde71ea29a4b76f # v0.1.0
+      with:
+        directory: .build

--- a/publish_main/action.yml
+++ b/publish_main/action.yml
@@ -1,0 +1,39 @@
+---
+name: Publish image
+description: Publish artifacts on the default branch.
+inputs:
+  docker_hub_organization:
+    description: DockerHub organization
+    default: prom
+  docker_hub_login:
+    description: DockerHub username
+  docker_hub_password:
+    description: DockerHub password
+  quay_io_organization:
+    description: Quay.io organization
+    default: prometheus
+  quay_io_login:
+    description: Quay.io username
+  quay_io_password:
+    description: Quay.io password
+runs:
+  using: composite
+  steps:
+    - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
+      with:
+        enable_docker_multibuild: true
+    - uses: prometheus/promci-artifacts/restore@f9a587dbc0b2c78a0c54f8ad1cde71ea29a4b76f # v0.1.0
+    - uses: prometheus/promci-images/publish@43087125ee33af44414b41d98d7180a45f1f6447 # v0.1.0
+      if: ${{ inputs.docker_hub_organization != '' && inputs.docker_hub_login != '' }}
+      with:
+        registry: docker.io
+        organization: ${{ inputs.docker_hub_organization }}
+        login: ${{ inputs.docker_hub_login }}
+        password: ${{ inputs.docker_hub_password }}
+    - uses: prometheus/promci-images/publish@43087125ee33af44414b41d98d7180a45f1f6447 # v0.1.0
+      if: ${{ inputs.quay_io_organization != '' && inputs.quay_io_login != '' }}
+      with:
+        registry: quay.io
+        organization: ${{ inputs.quay_io_organization }}
+        login: ${{ inputs.quay_io_login }}
+        password: ${{ inputs.quay_io_password }}

--- a/publish_release/action.yml
+++ b/publish_release/action.yml
@@ -1,0 +1,59 @@
+name: Publish release
+description: Publish tagged release artifacts
+inputs:
+  docker_hub_organization:
+    description: DockerHub organization
+    default: prom
+  docker_hub_login:
+    description: DockerHub username
+  docker_hub_password:
+    description: DockerHub password
+  quay_io_organization:
+    description: Quay.io organization
+    default: prometheus
+  quay_io_login:
+    description: Quay.io username
+  quay_io_password:
+    description: Quay.io password
+  github_token:
+    description: Github Token
+  promu_config:
+    description: Config file for promu
+    default: .promu.yml
+runs:
+  using: composite
+  steps:
+    - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
+      with:
+        enable_docker_multibuild: true
+        clean-runner-disk: true
+    - uses: prometheus/promci-artifacts/restore@f9a587dbc0b2c78a0c54f8ad1cde71ea29a4b76f # v0.1.0
+    - run: ~/go/bin/promu -c ${{ inputs.promu_config}} crossbuild tarballs
+      shell: bash
+    - run: ~/go/bin/promu -c ${{ inputs.promu_config}} checksum .tarballs
+      shell: bash
+    - run: ~/go/bin/promu -c ${{ inputs.promu_config}} release .tarballs
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+    - uses: prometheus/promci-images/publish_release@43087125ee33af44414b41d98d7180a45f1f6447 # v0.1.0
+      if: ${{ inputs.docker_hub_organization != '' && inputs.docker_hub_login != '' }}
+      with:
+        registry: docker.io
+        organization: ${{ inputs.docker_hub_organization }}
+        login: ${{ inputs.docker_hub_login }}
+        password: ${{ inputs.docker_hub_password }}
+    - uses: prometheus/promci-images/publish_release@43087125ee33af44414b41d98d7180a45f1f6447 # v0.1.0
+      if: ${{ inputs.quay_io_organization != '' && inputs.quay_io_login != '' }}
+      with:
+        registry: quay.io
+        organization: ${{ inputs.quay_io_organization }}
+        login: ${{ inputs.quay_io_login }}
+        password: ${{ inputs.quay_io_password }}
+    - uses: prometheus/promci-images/publish_release@43087125ee33af44414b41d98d7180a45f1f6447 # v0.1.0
+      if: ${{ inputs.ghcr_io_organization != '' && inputs.ghcr_io_login != '' }}
+      with:
+        registry: ghcr.io
+        organization: ${{ inputs.ghcr_io_organization }}
+        login: ${{ inputs.ghcr_io_login }}
+        password: ${{ inputs.ghcr_io_password }}


### PR DESCRIPTION
Add new direct use actions to replace the existing style.
* Deprecate old action use.
* Update dependabot.
* Document new usage.
* Add CI testing for new actions only.

Fixes: https://github.com/prometheus/promci/issues/69