### PR TITLE
Fix top-level action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - name: "WARNING: Deprecated action"
       run: echo "This action has been deprecated in favor of prometheus/promci/<action>@<sha> actions"
+      shell: bash
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: 'prometheus/promci'


### PR DESCRIPTION
Fix the `run` in the top-level action.

```
The template is not valid. prometheus/promci/769ee18070cd21cfc2a24fa912349fd3e48dee58/action.yml (Line: 6, Col: 7): Required property is missing: shell
```