### PR TITLE
Move back to upstream validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Validate Workflows and Custom Actions
-        uses: superq/action-validator@97a4e9c86388ddcc54614fb3e849a2fd4f7e124d # https://github.com/mpalmer/action-validator/pull/117
+        uses: mpalmer/action-validator@76a805bbfcba3506d6cdb4bba1810ab504e0d72b # v0.9.0
         with:
           patterns: |-
             .github/workflows/*.yml


### PR DESCRIPTION
Migrate back to the upstream actions validator now that the fix PR hsa been merged and released.