### PR TITLE
publish_release: fetch tags during checkout

### DIFF
--- a/publish_release/action.yml
+++ b/publish_release/action.yml
@@ -44,6 +44,7 @@ runs:
       if: inputs.checkout == 'true'
       with:
         persist-credentials: false
+        fetch-tags: true
     - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
       with:
         enable_docker_multibuild: true


### PR DESCRIPTION
The publish_release action pushes container images tagged 'latest'. To decide whether the release being published is actually the newest one, the image publishing step compares the release tag against the full list of existing tags. With the default shallow checkout (fetch-depth: 1) no tags are fetched, so that comparison can't see prior releases and may overwrite 'latest' when re-publishing or patching an older release.

Set fetch-tags: true so the complete tag list is available and 'latest' is only updated for the genuinely newest release.