### PR TITLE
Add workflow that allows triagers to approve workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           patterns: |-
             .github/workflows/*.yml
+            approve_workflows/action.yml
             build/action.yml
             publish_main/action.yml
             publish_release/action.yml

--- a/README.md
+++ b/README.md
@@ -32,3 +32,27 @@ jobs:
           quay_io_password: ${{ secrets.quay_io_password }}
           github_token: ${{ github.token }}
 ```
+
+### Approving pull request workflows
+
+The workflow approval action lets a trusted collaborator approve CI runs from
+public forks when the collaborator comments `/workflow-approve` on
+the pull request. The commenter must have triage access or higher.
+
+Use the action from a workflow triggered by `issue_comment`:
+
+```yaml
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: prometheus/promci/approve_workflows@<sha>
+        with:
+          github_token: ${{ github.token }}
+```
+
+Pin the action to a full commit SHA.

--- a/approve_workflows/action.yml
+++ b/approve_workflows/action.yml
@@ -1,0 +1,22 @@
+---
+name: Approve pending workflows
+description: Approve CI runs from trusted pull request commenters.
+inputs:
+  github_token:
+    description: GitHub token with permission to approve workflow runs
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Approve pending workflows
+      if: >-
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.body == '/workflow-approve'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        PR_NUMBER: ${{ github.event.issue.number }}
+        SENDER: ${{ github.event.comment.user.login }}
+        COMMENT: ${{ github.event.comment.body }}
+      run: bash "${{ github.action_path }}/approve-workflows.sh"

--- a/approve_workflows/action.yml
+++ b/approve_workflows/action.yml
@@ -18,5 +18,4 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
         PR_NUMBER: ${{ github.event.issue.number }}
         SENDER: ${{ github.event.comment.user.login }}
-        COMMENT: ${{ github.event.comment.body }}
       run: bash "${{ github.action_path }}/approve-workflows.sh"

--- a/approve_workflows/approve-workflows.sh
+++ b/approve_workflows/approve-workflows.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_REPOSITORY:-}" || -z "${PR_NUMBER:-}" || -z "${SENDER:-}" || -z "${COMMENT:-}" ]]; then
+    echo "GITHUB_REPOSITORY, PR_NUMBER, SENDER, and COMMENT must be set"
+    exit 1
+fi
+
+if [[ "${COMMENT}" != "/workflow-approve" ]]; then
+    echo "Ignoring comment that is not the workflow approval command"
+    exit 0
+fi
+
+if ! ROLE=$(
+    gh api \
+        "repos/${GITHUB_REPOSITORY}/collaborators/${SENDER}/permission" \
+        --jq '.role_name' \
+        2>/dev/null
+); then
+    echo "Unable to determine repository access for ${SENDER}"
+    exit 1
+fi
+
+case "${ROLE}" in
+    triage | write | maintain | admin)
+        ;;
+    *)
+        echo "${SENDER} does not have triage or higher access to ${GITHUB_REPOSITORY}"
+        gh pr comment "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "Workflow approval requires **triage access or higher** on this repository."
+        exit 0
+        ;;
+esac
+
+if ! HEAD_SHA=$(
+    gh pr view "${PR_NUMBER}" \
+        --repo "${GITHUB_REPOSITORY}" \
+        --json headRefOid \
+        --jq '.headRefOid // empty'
+); then
+    echo "Unable to determine the head commit for pull request ${PR_NUMBER}"
+    exit 1
+fi
+
+if [[ -z "${HEAD_SHA}" ]]; then
+    echo "Pull request ${PR_NUMBER} does not have a head commit"
+    exit 1
+fi
+
+echo "Finding pull request workflows awaiting approval for ${HEAD_SHA}"
+
+mapfile -t WAITING_RUNS < <(
+    gh run list \
+        --repo "${GITHUB_REPOSITORY}" \
+        --commit "${HEAD_SHA}" \
+        --limit 100 \
+        --json databaseId,conclusion,event \
+        --jq '.[] | select(.conclusion == "action_required" and .event == "pull_request") | .databaseId'
+)
+
+if [[ ${#WAITING_RUNS[@]} -eq 0 ]]; then
+    echo "No workflows are awaiting approval"
+    exit 0
+fi
+
+for RUN_ID in "${WAITING_RUNS[@]}"; do
+    echo "Approving workflow run ${RUN_ID}"
+    gh api \
+        --method POST \
+        "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/approve" \
+        --silent
+done

--- a/approve_workflows/approve-workflows.sh
+++ b/approve_workflows/approve-workflows.sh
@@ -2,14 +2,9 @@
 
 set -euo pipefail
 
-if [[ -z "${GITHUB_REPOSITORY:-}" || -z "${PR_NUMBER:-}" || -z "${SENDER:-}" || -z "${COMMENT:-}" ]]; then
-    echo "GITHUB_REPOSITORY, PR_NUMBER, SENDER, and COMMENT must be set"
+if [[ -z "${GITHUB_REPOSITORY:-}" || -z "${PR_NUMBER:-}" || -z "${SENDER:-}" ]]; then
+    echo "GITHUB_REPOSITORY, PR_NUMBER, and SENDER must be set"
     exit 1
-fi
-
-if [[ "${COMMENT}" != "/workflow-approve" ]]; then
-    echo "Ignoring comment that is not the workflow approval command"
-    exit 0
 fi
 
 if ! ROLE=$(


### PR DESCRIPTION
Add a CI workflow that allows folks with `triage` access to approve CI runs, overriding the GitHub default behavior, which requires at least `write` access.